### PR TITLE
fix guild invite page

### DIFF
--- a/system/pages/guilds/accept_invite.php
+++ b/system/pages/guilds/accept_invite.php
@@ -39,13 +39,10 @@ if(isset($_REQUEST['todo']) && $_REQUEST['todo'] == 'save') {
 		$player->find($name);
 		if(!$player->isLoaded()) {
 			$errors[] = 'Player with name <b>'.$name.'</b> doesn\'t exist.';
-		}
-		else
-		{
-			$rank_of_player = $player->getRank();
-			if($rank_of_player->isLoaded()) {
-				$errors[] = 'Character with name <b>'.$name.'</b> is already in guild. You must leave guild before you join other guild.';
-			}
+		}else if ($player->getAccountID() != $account_logged->getId()) {
+			//$errors[] = 'Character with name <b> ' . $name. ' </b> is not in your account.';
+		}else if ($player->getRank()->isLoaded()){
+			$errors[] = 'Character with name <b>'.$name.'</b> is already in guild. You must leave guild before you join other guild.';
 		}
 	}
 }
@@ -56,6 +53,7 @@ if(isset($_REQUEST['todo']) && $_REQUEST['todo'] == 'save') {
 		include(SYSTEM . 'libs/pot/InvitesDriver.php');
 		new InvitesDriver($guild);
 		$invited_list = $guild->listInvites();
+		var_dump($invited_list);
 		if(count($invited_list) > 0) {
 			foreach($invited_list as $invited) {
 				if($invited->getName() == $player->getName()) {
@@ -63,9 +61,8 @@ if(isset($_REQUEST['todo']) && $_REQUEST['todo'] == 'save') {
 				}
 			}
 		}
-
 		if(!$is_invited) {
-			$errors[] = 'Character '.$player->getName.' isn\'t invited to guild <b>'.$guild->getName().'</b>.';
+			$errors[] = 'Character '.$player->getName() .' isn\'t invited to guild <b>'.$guild->getName().'</b>.';
 		}
 	}
 }

--- a/system/pages/guilds/accept_invite.php
+++ b/system/pages/guilds/accept_invite.php
@@ -40,7 +40,7 @@ if(isset($_REQUEST['todo']) && $_REQUEST['todo'] == 'save') {
 		if(!$player->isLoaded()) {
 			$errors[] = 'Player with name <b>'.$name.'</b> doesn\'t exist.';
 		}else if ($player->getAccountID() != $account_logged->getId()) {
-			//$errors[] = 'Character with name <b> ' . $name. ' </b> is not in your account.';
+			$errors[] = 'Character with name <b> ' . $name. ' </b> is not in your account.';
 		}else if ($player->getRank()->isLoaded()){
 			$errors[] = 'Character with name <b>'.$name.'</b> is already in guild. You must leave guild before you join other guild.';
 		}

--- a/system/pages/guilds/accept_invite.php
+++ b/system/pages/guilds/accept_invite.php
@@ -53,7 +53,6 @@ if(isset($_REQUEST['todo']) && $_REQUEST['todo'] == 'save') {
 		include(SYSTEM . 'libs/pot/InvitesDriver.php');
 		new InvitesDriver($guild);
 		$invited_list = $guild->listInvites();
-		var_dump($invited_list);
 		if(count($invited_list) > 0) {
 			foreach($invited_list as $invited) {
 				if($invited->getName() == $player->getName()) {


### PR DESCRIPTION
people were able to send false data when accepting guild invites and join with any player from outside its account

-> invite anyone (that isn't in your account)
-> invite someone from your account, then you get access to the "accept invite" button
-> before accepting, edit the radiobutton value and put the previous character name (the one that isn't in your account)
-> send

furthermore, there was an error at line 68
