### PR TITLE
fix: query blob param escape

### DIFF
--- a/system/libs/CreateCharacter.php
+++ b/system/libs/CreateCharacter.php
@@ -242,8 +242,10 @@ class CreateCharacter
 		}
 
 		$loaded_items_to_copy = $db->query("SELECT * FROM player_items WHERE player_id = ".$char_to_copy->getId()."");
-		foreach($loaded_items_to_copy as $save_item)
-			$db->query("INSERT INTO `player_items` (`player_id` ,`pid` ,`sid` ,`itemtype`, `count`, `attributes`) VALUES ('".$player->getId()."', '".$save_item['pid']."', '".$save_item['sid']."', '".$save_item['itemtype']."', '".$save_item['count']."', '".$save_item['attributes']."');");
+		foreach($loaded_items_to_copy as $save_item) {
+			$blob = addslashes($save_item['attribute']);
+			$db->query("INSERT INTO `player_items` (`player_id` ,`pid` ,`sid` ,`itemtype`, `count`, `attributes`) VALUES ('".$player->getId()."', '".$save_item['pid']."', '".$save_item['sid']."', '".$save_item['itemtype']."', '".$save_item['count']."', '{$blob}');");
+		}
 
 		global $twig;
 		$twig->display('success.html.twig', array(


### PR DESCRIPTION
if you have a letter/paper with a single quote, that breaks the query. just escaping the item to prevent crashes when copy char.

potential SQL injection,
maybe `$db->quote` should be better instead addslashes?

![Untitled-1](https://user-images.githubusercontent.com/2898638/181155927-41affdcf-3442-45ea-971f-3c8823f3fd06.png)
![image](https://user-images.githubusercontent.com/2898638/181155816-0cba2d80-2ec9-4144-9a3c-48b54c25beff.png)
