### PR TITLE
feat: add hook admin menu

### DIFF
--- a/admin/template/menus.php
+++ b/admin/template/menus.php
@@ -1,8 +1,8 @@
 <?php
 
 $menus = [
-	['name' => 'Dashboard', 'icon' => 'tachometer-alt', 'link' => 'dashboard'],
-	['name' => 'News', 'icon' => 'newspaper',  'link' =>
+	['name' => 'Dashboard', 'icon' => 'tachometer-alt', 'order' => 10, 'link' => 'dashboard'],
+	['name' => 'News', 'icon' => 'newspaper', 'order' => 20, 'link' =>
 		[
 			['name' => 'View', 'link' => 'news', 'order' => 10],
 			['name' => 'Add news', 'link' => 'news&action=new&type=1', 'order' => 20],
@@ -10,35 +10,35 @@ $menus = [
 			['name' => 'Add article', 'link' => 'news&action=new&type=3', 'order' => 40],
 		],
 	],
-	['name' => 'Changelogs', 'icon' => 'newspaper',  'link' =>
+	['name' => 'Changelogs', 'icon' => 'newspaper', 'order' => 30, 'link' =>
 		[
 			['name' => 'View', 'link' => 'changelog', 'order' => 10],
 			['name' => 'Add', 'link' => 'changelog&action=new', 'order' => 20],
 		],
 	],
-	['name' => 'Mailer', 'icon' => 'envelope', 'link' => 'mailer', 'disabled' => !config('mail_enabled')],
-	['name' => 'Pages', 'icon' => 'book', 'link' =>
+	['name' => 'Mailer', 'icon' => 'envelope', 'order' => 40, 'link' => 'mailer', 'disabled' => !config('mail_enabled')],
+	['name' => 'Pages', 'icon' => 'book', 'order' => 50, 'link' =>
 		[
 			['name' => 'View', 'link' => 'pages', 'order' => 10],
 			['name' => 'Add', 'link' => 'pages&action=new', 'order' => 20],
 		],
 	],
-	['name' => 'Menus', 'icon' => 'list', 'link' => 'menus'],
-	['name' => 'Plugins', 'icon' => 'plug', 'link' => 'plugins'],
-	['name' => 'Server Data', 'icon' => 'gavel', 'link' => 'data'],
-	['name' => 'Editor', 'icon' => 'edit', 'link' =>
+	['name' => 'Menus', 'icon' => 'list', 'order' => 60, 'link' => 'menus'],
+	['name' => 'Plugins', 'icon' => 'plug', 'order' => 70, 'link' => 'plugins'],
+	['name' => 'Server Data', 'icon' => 'gavel', 'order' => 80, 'link' => 'data'],
+	['name' => 'Editor', 'icon' => 'edit', 'order' => 90, 'link' =>
 		[
 			['name' => 'Accounts', 'link' => 'accounts', 'order' => 10],
 			['name' => 'Players', 'link' => 'players', 'order' => 20],
 		],
 	],
-	['name' => 'Tools', 'icon' => 'tools', 'link' =>
+	['name' => 'Tools', 'icon' => 'tools', 'order' => 100, 'link' =>
 		[
 			['name' => 'Notepad', 'link' => 'notepad', 'order' => 10],
 			['name' => 'phpinfo', 'link' => 'phpinfo', 'order' => 20],
 		],
 	],
-	['name' => 'Logs', 'icon' => 'bug', 'link' =>
+	['name' => 'Logs', 'icon' => 'bug', 'order' => 110, 'link' =>
 		[
 			['name' => 'Logs', 'link' => 'logs', 'order' => 10],
 			['name' => 'Reports', 'link' => 'reports', 'order' => 20],
@@ -48,6 +48,10 @@ $menus = [
 ];
 
 $hooks->trigger(HOOK_ADMIN_MENU);
+
+usort($menus, function ($a, $b) {
+	return $a['order'] - $b['order'];
+});
 
 foreach ($menus as $i => $menu) {
 	if (isset($menu['link']) && is_array($menu['link'])) {

--- a/admin/template/menus.php
+++ b/admin/template/menus.php
@@ -49,12 +49,4 @@ $menus = [
 
 $hooks->trigger(HOOK_ADMIN_MENU);
 
-foreach ($menus as $i => $menu) {
-	if (isset($menu['link']) && is_array($menu['link'])) {
-		usort($menus[$i]['link'], function ($a, $b) {
-			return strcmp($a['name'], $b['name']);
-		});
-	}
-}
-
 return $menus;

--- a/admin/template/menus.php
+++ b/admin/template/menus.php
@@ -1,6 +1,6 @@
 <?php
 
-return [
+$menus = [
 	['name' => 'Dashboard', 'icon' => 'tachometer-alt', 'link' => 'dashboard'],
 	['name' => 'News', 'icon' => 'newspaper',  'link' =>
 		[
@@ -46,3 +46,15 @@ return [
 		],
 	],
 ];
+
+$hooks->trigger(HOOK_ADMIN_MENU);
+
+foreach ($menus as $i => $menu) {
+	if (isset($menu['link']) && is_array($menu['link'])) {
+		usort($menus[$i]['link'], function ($a, $b) {
+			return strcmp($a['name'], $b['name']);
+		});
+	}
+}
+
+return $menus;

--- a/admin/template/menus.php
+++ b/admin/template/menus.php
@@ -4,23 +4,23 @@ $menus = [
 	['name' => 'Dashboard', 'icon' => 'tachometer-alt', 'link' => 'dashboard'],
 	['name' => 'News', 'icon' => 'newspaper',  'link' =>
 		[
-			['name' => 'View', 'link' => 'news'],
-			['name' => 'Add news', 'link' => 'news&action=new&type=1'],
-			['name' => 'Add ticker', 'link' => 'news&action=new&type=2'],
-			['name' => 'Add article', 'link' => 'news&action=new&type=3'],
+			['name' => 'View', 'link' => 'news', 'order' => 1],
+			['name' => 'Add news', 'link' => 'news&action=new&type=1', 'order' => 2],
+			['name' => 'Add ticker', 'link' => 'news&action=new&type=2', 'order' => 3],
+			['name' => 'Add article', 'link' => 'news&action=new&type=3', 'order' => 4],
 		],
 	],
 	['name' => 'Changelogs', 'icon' => 'newspaper',  'link' =>
 		[
-			['name' => 'View', 'link' => 'changelog'],
-			['name' => 'Add', 'link' => 'changelog&action=new'],
+			['name' => 'View', 'link' => 'changelog', 'order' => 1],
+			['name' => 'Add', 'link' => 'changelog&action=new', 'order' => 2],
 		],
 	],
 	['name' => 'Mailer', 'icon' => 'envelope', 'link' => 'mailer', 'disabled' => !config('mail_enabled')],
 	['name' => 'Pages', 'icon' => 'book', 'link' =>
 		[
-			['name' => 'View', 'link' => 'pages'],
-			['name' => 'Add', 'link' => 'pages&action=new'],
+			['name' => 'View', 'link' => 'pages', 'order' => 1],
+			['name' => 'Add', 'link' => 'pages&action=new', 'order' => 2],
 		],
 	],
 	['name' => 'Menus', 'icon' => 'list', 'link' => 'menus'],
@@ -28,25 +28,33 @@ $menus = [
 	['name' => 'Server Data', 'icon' => 'gavel', 'link' => 'data'],
 	['name' => 'Editor', 'icon' => 'edit', 'link' =>
 		[
-			['name' => 'Accounts', 'link' => 'accounts'],
-			['name' => 'Players', 'link' => 'players'],
+			['name' => 'Accounts', 'link' => 'accounts', 'order' => 1],
+			['name' => 'Players', 'link' => 'players', 'order' => 2],
 		],
 	],
 	['name' => 'Tools', 'icon' => 'tools', 'link' =>
 		[
-			['name' => 'Notepad', 'link' => 'notepad'],
-			['name' => 'phpinfo', 'link' => 'phpinfo'],
+			['name' => 'Notepad', 'link' => 'notepad', 'order' => 1],
+			['name' => 'phpinfo', 'link' => 'phpinfo', 'order' => 2],
 		],
 	],
 	['name' => 'Logs', 'icon' => 'bug', 'link' =>
 		[
-			['name' => 'Logs', 'link' => 'logs'],
-			['name' => 'Reports', 'link' => 'reports'],
-			['name' => 'Visitors', 'icon' => 'user', 'link' => 'visitors'],
+			['name' => 'Logs', 'link' => 'logs', 'order' => 1],
+			['name' => 'Reports', 'link' => 'reports', 'order' => 2],
+			['name' => 'Visitors', 'icon' => 'user', 'link' => 'visitors', 'order' => 3],
 		],
 	],
 ];
 
 $hooks->trigger(HOOK_ADMIN_MENU);
+
+foreach ($menus as $i => $menu) {
+	if (isset($menu['link']) && is_array($menu['link'])) {
+		usort($menus[$i]['link'], function ($a, $b) {
+			return $a['order'] - $b['order'];
+		});
+	}
+}
 
 return $menus;

--- a/admin/template/menus.php
+++ b/admin/template/menus.php
@@ -4,23 +4,23 @@ $menus = [
 	['name' => 'Dashboard', 'icon' => 'tachometer-alt', 'link' => 'dashboard'],
 	['name' => 'News', 'icon' => 'newspaper',  'link' =>
 		[
-			['name' => 'View', 'link' => 'news', 'order' => 1],
-			['name' => 'Add news', 'link' => 'news&action=new&type=1', 'order' => 2],
-			['name' => 'Add ticker', 'link' => 'news&action=new&type=2', 'order' => 3],
-			['name' => 'Add article', 'link' => 'news&action=new&type=3', 'order' => 4],
+			['name' => 'View', 'link' => 'news', 'order' => 10],
+			['name' => 'Add news', 'link' => 'news&action=new&type=1', 'order' => 20],
+			['name' => 'Add ticker', 'link' => 'news&action=new&type=2', 'order' => 30],
+			['name' => 'Add article', 'link' => 'news&action=new&type=3', 'order' => 40],
 		],
 	],
 	['name' => 'Changelogs', 'icon' => 'newspaper',  'link' =>
 		[
-			['name' => 'View', 'link' => 'changelog', 'order' => 1],
-			['name' => 'Add', 'link' => 'changelog&action=new', 'order' => 2],
+			['name' => 'View', 'link' => 'changelog', 'order' => 10],
+			['name' => 'Add', 'link' => 'changelog&action=new', 'order' => 20],
 		],
 	],
 	['name' => 'Mailer', 'icon' => 'envelope', 'link' => 'mailer', 'disabled' => !config('mail_enabled')],
 	['name' => 'Pages', 'icon' => 'book', 'link' =>
 		[
-			['name' => 'View', 'link' => 'pages', 'order' => 1],
-			['name' => 'Add', 'link' => 'pages&action=new', 'order' => 2],
+			['name' => 'View', 'link' => 'pages', 'order' => 10],
+			['name' => 'Add', 'link' => 'pages&action=new', 'order' => 20],
 		],
 	],
 	['name' => 'Menus', 'icon' => 'list', 'link' => 'menus'],
@@ -28,21 +28,21 @@ $menus = [
 	['name' => 'Server Data', 'icon' => 'gavel', 'link' => 'data'],
 	['name' => 'Editor', 'icon' => 'edit', 'link' =>
 		[
-			['name' => 'Accounts', 'link' => 'accounts', 'order' => 1],
-			['name' => 'Players', 'link' => 'players', 'order' => 2],
+			['name' => 'Accounts', 'link' => 'accounts', 'order' => 10],
+			['name' => 'Players', 'link' => 'players', 'order' => 20],
 		],
 	],
 	['name' => 'Tools', 'icon' => 'tools', 'link' =>
 		[
-			['name' => 'Notepad', 'link' => 'notepad', 'order' => 1],
-			['name' => 'phpinfo', 'link' => 'phpinfo', 'order' => 2],
+			['name' => 'Notepad', 'link' => 'notepad', 'order' => 10],
+			['name' => 'phpinfo', 'link' => 'phpinfo', 'order' => 20],
 		],
 	],
 	['name' => 'Logs', 'icon' => 'bug', 'link' =>
 		[
-			['name' => 'Logs', 'link' => 'logs', 'order' => 1],
-			['name' => 'Reports', 'link' => 'reports', 'order' => 2],
-			['name' => 'Visitors', 'icon' => 'user', 'link' => 'visitors', 'order' => 3],
+			['name' => 'Logs', 'link' => 'logs', 'order' => 10],
+			['name' => 'Reports', 'link' => 'reports', 'order' => 20],
+			['name' => 'Visitors', 'icon' => 'user', 'link' => 'visitors', 'order' => 30],
 		],
 	],
 ];

--- a/system/hooks.php
+++ b/system/hooks.php
@@ -49,8 +49,9 @@ define('HOOK_ACCOUNT_CREATE_AFTER_TOWNS', ++$i);
 define('HOOK_ACCOUNT_CREATE_BEFORE_SUBMIT_BUTTON', ++$i);
 define('HOOK_ACCOUNT_CREATE_AFTER_FORM', ++$i);
 define('HOOK_ACCOUNT_CREATE_AFTER_SUBMIT', ++$i);
+define('HOOK_ADMIN_MENU', ++$i);
 define('HOOK_FIRST', HOOK_STARTUP);
-define('HOOK_LAST', HOOK_ACCOUNT_CREATE_AFTER_SUBMIT);
+define('HOOK_LAST', HOOK_ADMIN_MENU);
 
 require_once LIBS . 'plugins.php';
 class Hook


### PR DESCRIPTION
allows to add new admin menus using hooks

examples:
```php
global $menus;

// new menu
$menus[] = [
    'name' => 'Custom Admin Tools',
    'icon' => 'tools',
    'order' => 21,
    'link' => [
        ['name' => 'BAdmin', 'link' => 'admin', 'order' => 2],
        ['name' => 'Admin', 'link' => 'admin', 'order' => 1]
    ]
];

// new sub menu on existing menu
foreach ($menus as $i => $menu) {
    if (isset($menu['name']) && $menu['name'] === 'Tools') {
        $menus[$i]['link'][] = ['name' => 'Xablau', 'link' => 'admin', 'order' => 0];
        break;
    }
}
```

<img width="250" alt="Captura de Tela 2022-11-28 às 13 01 16" src="https://user-images.githubusercontent.com/2898638/204337549-9597d3e2-989c-47ab-820b-f37c289312e9.png">
